### PR TITLE
feat: allow to provide custom fetch function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,9 @@ const { Renderer } = require("./renderer");
  * @param {string} options.url
  * @param {((window: import('jsdom').JSDOM['window']) => void)=} options.setupGlobals
  * @param {((url: string, options: import('jsdom').FetchOptions) => Promise<string> | null)=} options.resourceLoader
+ * @param {(typeof window['fetch'])=} options.fetch
  */
-async function render({ html, url, setupGlobals, resourceLoader }) {
+async function render({ html, url, setupGlobals, resourceLoader, fetch }) {
   const renderer = new Renderer();
 
   const dom = new JSDOM(html, {
@@ -19,7 +20,7 @@ async function render({ html, url, setupGlobals, resourceLoader }) {
         setupGlobals(window);
       }
 
-      renderer.setup(window);
+      renderer.setup(window, fetch);
     },
     runScripts: "dangerously",
     pretendToBeVisual: true,

--- a/tests/with-custom-fetch/app.jsx
+++ b/tests/with-custom-fetch/app.jsx
@@ -1,0 +1,19 @@
+import React, { useState, useEffect } from "react";
+import ReactDOM from "react-dom";
+
+const App = () => {
+  const [state, setState] = useState(0);
+
+  useEffect(() => {
+    fetch("https://api.github.com/repos/knisterpeter/react-ssr-renderer")
+      .then(() => setState(1))
+      .catch(() => setState(2));
+  }, []);
+
+  return <p>{state}</p>;
+};
+
+const app = document.createElement("div");
+document.body.appendChild(app);
+
+ReactDOM.render(<App />, app);

--- a/tests/with-custom-fetch/test.js
+++ b/tests/with-custom-fetch/test.js
@@ -1,0 +1,29 @@
+const { runWebpack, resourceLoader } = require("../test-helper");
+
+const { render } = require("../..");
+
+test("Render app with react-query", async () => {
+  const fs = await runWebpack(require.resolve("./app.jsx"));
+  const host = "http://localhost";
+
+  const dom = await render({
+    html: `
+      <body>
+        <script src="/app.js"></script>
+      </body>
+    `,
+    url: host,
+    resourceLoader: resourceLoader(fs, host),
+    async fetch() {
+      throw new Error("fetch not allowed");
+    },
+  });
+
+  const {
+    window: { document },
+  } = dom;
+
+  const p = document.querySelector("p");
+
+  expect(p).toHaveTextContent("2");
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,12 +6,14 @@ import { Renderer } from "./renderer";
  * @param {string} options.url
  * @param {((window: import('jsdom').JSDOM['window']) => void)=} options.setupGlobals
  * @param {((url: string, options: import('jsdom').FetchOptions) => Promise<string> | null)=} options.resourceLoader
+ * @param {(typeof window['fetch'])=} options.fetch
  */
-export function render({ html, url, setupGlobals, resourceLoader }: {
+export function render({ html, url, setupGlobals, resourceLoader, fetch }: {
     html: string;
     url: string;
     setupGlobals?: ((window: import('jsdom').JSDOM['window']) => void) | undefined;
     resourceLoader?: ((url: string, options: import('jsdom').FetchOptions) => Promise<string> | null) | undefined;
+    fetch?: (typeof window['fetch']) | undefined;
 }): Promise<JSDOM>;
 import { JSDOM } from "jsdom";
 export { Renderer };


### PR DESCRIPTION
To customize fetch behavior during server rendering, this adds an
option to inject a custom fetch function.
This could for example be used to fetch from an internal host or
wrap the fetch calls with some extra headers.
